### PR TITLE
Quantizer bug fixes

### DIFF
--- a/Firmware/IoMatrix.c
+++ b/Firmware/IoMatrix.c
@@ -58,7 +58,7 @@ static const uint8_t ledPinArray[12][2] PROGMEM = {
 };
 //-----------------------------------------------------------
 static uint16_t io_ledState=0xfff;		//state of the 12 LEDs == activated notes
-static uint8_t io_activeStep=2;			//current active quantisation step == currently played note
+static uint8_t io_activeStep=99;			//current active quantisation step == currently played note
 static uint16_t io_lastButtonState=0x00;
 //-----------------------------------------------------------
 void io_init()

--- a/Firmware/MCP4802.c
+++ b/Firmware/MCP4802.c
@@ -77,6 +77,8 @@ bit 11-0 D11:D0:DAC Input Data bits. Bit x is ignored.
 */
 void mcp4802_outputData(const uint8_t out1, const uint8_t out2)
 {
+  (void)out2;
+
 	//LDAC HIGH (no dac update, gate low)
 	MCP_CS_PORT |= (1<<MCP_LDAC_PIN);
 	//CS low -> start write cmd

--- a/Firmware/adc.c
+++ b/Firmware/adc.c
@@ -28,8 +28,7 @@ void adc_init(void)
 {
 	DDRC &= ~(1<<PC0); //pin input
 	PORTC &= ~(1<<PC0); //no pullup
-  
-	uint16_t result;
+
  	// AVCC as ref voltage
 	ADMUX =  (1<<REFS0);
 	ADMUX = (ADMUX & ~(0x1F)) | (0 & 0x1F); //always channel 0
@@ -39,8 +38,6 @@ void adc_init(void)
  	// dummy readout
 	ADCSRA |= (1<<ADSC);                  // single readout
 	while (ADCSRA & (1<<ADSC) ) {}        // wait to finish
-	// read result 
-	result = ADCW;
 };
 //-----------------------------------------------------------
 uint16_t adc_read()


### PR DESCRIPTION
Hi there

This PR addresses a couple of small issues I found with the quantiser:
- Fixed a couple of compiler warnings.
- On startup, the `activeStep` defaults to `2` which is misleading. It now defaults to `99` (no step).
- There was an issue where the same note couldn't be played twice if running in trigger mode. It makes sense to not allow the same consecutive note in free-running mode, but in trigger mode it should be possible. This is now fixed.

Enjoy!
