### PR TITLE
Fix an issue with the active step LED

### DIFF
--- a/Firmware/IoMatrix.c
+++ b/Firmware/IoMatrix.c
@@ -58,7 +58,7 @@ static const uint8_t ledPinArray[12][2] PROGMEM = {
 };
 //-----------------------------------------------------------
 static uint16_t io_ledState=0xfff;		//state of the 12 LEDs == activated notes
-static uint8_t io_activeStep=2;			//current active quantisation step == currently played note
+static uint8_t io_activeStep=99;			//current active quantisation step == currently played note
 static uint16_t io_lastButtonState=0x00;
 //-----------------------------------------------------------
 void io_init()

--- a/Firmware/IoMatrix.c
+++ b/Firmware/IoMatrix.c
@@ -188,17 +188,20 @@ void io_processLedPipelined()
 {
   turnAllLedsOff();
 
-  if(ledState==io_activeStep)
+  if ( (io_ledState & (1<<ledState)) > 0)
   {
-    //this step is currently played => set color 1
-    turnLedOn(ledState,0);
-  } 
-  else if ( (io_ledState & (1<<ledState)) > 0)
-  {
-    //step is active => colour 2
-    turnLedOn(ledState,1);
+    if(ledState==io_activeStep)
+    {
+      //this step is currently played => set color 1
+      turnLedOn(ledState,0);
+    }
+    else
+    {
+      //step is active => colour 2
+      turnLedOn(ledState,1);
+    }
   }
-  
+
   ledState++;
   if(ledState>=12) ledState=0;
 };


### PR DESCRIPTION
This PR fixes an issue where the active step LED would still be shown even if the button was deselected.

On startup, the activeStep defaults to 2 which is misleading. It now defaults to 99 (no step).